### PR TITLE
Fix compatibility with mdformat 1.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,25 +13,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.11
-    - uses: pre-commit/action@v2.0.0
+        python-version: 3.14
+    - uses: pre-commit/action@v3.0.1
 
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -47,10 +47,10 @@ jobs:
         pytest --cov=mdformat_simple_breaks --cov-report=xml --cov-report=term-missing
 
     - name: Upload to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
-      uses: codecov/codecov-action@v3
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.14
+      uses: codecov/codecov-action@v5
       with:
-        name: pytests-py3.11
+        name: pytests-py3.14
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
 
@@ -81,11 +81,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/checkout@v5
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.11
+        python-version: 3.14
     - name: install flit
       run: |
         pip install flit~=3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
@@ -8,19 +8,19 @@ repos:
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
+  rev: v1.10.0
   hooks:
   - id: python-check-blanket-noqa
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.11.4
+  rev: 7.0.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 25.9.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
     additional_dependencies:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,7 @@ tox
 and with test coverage:
 
 ```bash
-tox -e py37-cov
+tox -e py314-cov
 ```
 
 The easiest way to write tests, is to edit tests/fixtures.md
@@ -27,7 +27,7 @@ The easiest way to write tests, is to edit tests/fixtures.md
 To run the code formatting and style checks:
 
 ```bash
-tox -e py37-pre-commit
+tox -e py314-pre-commit
 ```
 
 or directly
@@ -40,7 +40,7 @@ pre-commit run --all
 To run the pre-commit hook test:
 
 ```bash
-tox -e py37-hook
+tox -e py314-hook
 ```
 
 ## Publish to PyPi

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the following to your `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.13  # Use the ref you want to point at
+  rev: 1.0.0  # Use the ref you want to point at
   hooks:
     - id: mdformat
       additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = ["mdformat", "markdown", "markdown-it"]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
-    "mdformat >=0.7.0,<0.8.0",
+    "mdformat ~= 1.0.0",
 ]
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 test = [
-    "pytest~=6.0",
+    "pytest >= 8.4.0",
     "coverage",
     "pytest-cov",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py3{7,8,9,10,11}, coverage, pre-commit, hook
+envlist = py3{10,11,12,13,14}, coverage, pre-commit, hook
 isolated_build = True
 
-[testenv:py3{7,8,9,10,11}]
+[testenv:py3{10,11,12,13,14}]
 extras = test
 commands = pytest {posargs}
 


### PR DESCRIPTION
Fix: https://github.com/csala/mdformat-simple-breaks/issues/3

Given the big changes, I couldn't help but try to update things left and right:
- Bump minimal Python to 3.10 (to align it with `mdformat 1.0.0` owns requirement)
- Add tests on Python 3.12, 3.13 and 3.14
- Remove tests on Python 3.7, 3.8 and 3.9
- Bump `pytest >= 8.4.0` (first version to support Python 3.14) 
- Bump all GitHub workflow actions
- Update all pre-commit hooks dependencies to their latest release

Sorry if this PR feels a bit bigger in scope than simply fixing `mdformat 1.0.0` compatibility. So please tell me if some changes are too aggressive in which case I'll be happy to scale down my propositions.