### PR TITLE
Defer typing imports

### DIFF
--- a/mdformat_simple_breaks/plugin.py
+++ b/mdformat_simple_breaks/plugin.py
@@ -1,10 +1,14 @@
 """Main plugin module."""
 
-from typing import Mapping
+from __future__ import annotations
 
-from markdown_it import MarkdownIt
-from mdformat.renderer import RenderContext, RenderTreeNode
-from mdformat.renderer.typing import Render
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from markdown_it import MarkdownIt
+    from mdformat.renderer import RenderContext, RenderTreeNode
+    from mdformat.renderer.typing import Render
 
 
 def update_mdit(mdit: MarkdownIt) -> None:


### PR DESCRIPTION
This is a small proposal that I am starting to apply everywhere in my own projects.

It fallows the lead of Python stdlib: https://github.com/python/cpython/issues/118761

The idea consist in hiding all typing imports behind a hard-coded `TYPE_CHECKING` variable. Which [Mypy is able to pick them up correctly](https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks), because `TYPE_CHECKING` is always evaluated to `False` at runtime, and to `True` [during static analysis](https://github.com/python/mypy/blob/6aa44da/mypy/reachability.py#L152).

See an example at: https://github.com/python/cpython/pull/128907